### PR TITLE
Switch create account to post

### DIFF
--- a/django_code/account/templates/account/login.html
+++ b/django_code/account/templates/account/login.html
@@ -100,7 +100,7 @@
         <input class="btn" type="submit" value="Login">
     </form>
     <hr>
-    <form method="POST" id="create-account-form" name="create-account-form" onsubmit="return checkNewAccount()">
+    <form method="POST" id="create-account-form" name="create-account-form" onsubmit="return checkNewAccount()" action="createAccount">
         <b>Create Account:</b>
         {% csrf_token %}
         <br>

--- a/django_code/account/templates/account/login.html
+++ b/django_code/account/templates/account/login.html
@@ -84,13 +84,13 @@
     var checkUsername=function(){
         var available=document.getElementById("available");
         available.innerHTML = "";
-    	var ans=false;
-      
+        var ans=false;
+
         var req = new XMLHttpRequest();
         req.addEventListener("load", function() {
             if (this.status == 200) {
-				ans=JSON.parse(this.response);
-				ans=ans["username_available"];
+                ans=JSON.parse(this.response);
+                ans=ans["username_available"];
             }
             if(ans){
                   available.innerHTML="&#x2714;";
@@ -102,7 +102,7 @@
             }
         });
         req.open("GET", "/api/users/username_available?username="+document.getElementById("username").value);
-		req.send();
+        req.send();
     };
     </script>
 </head>

--- a/django_code/account/templates/account/login.html
+++ b/django_code/account/templates/account/login.html
@@ -41,7 +41,7 @@
            loginT.innerHTML = "Please enter a valid username<br>";
            return false;
         }
-        if (!form.email.value.match(/^(?:[\w.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)?$s/)) {
+        if (!form.email.value.match(/^(?:[\w.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)?$/)) {
            loginT.innerHTML = "Please enter a valid email, or no email at all.<br>";
            return false;
         }

--- a/django_code/account/templates/account/login.html
+++ b/django_code/account/templates/account/login.html
@@ -34,52 +34,33 @@
         req.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
         req.send(data);
     };
-    var createAccount = function () {
+    var checkNewAccount = function () {
         loginT = document.getElementById("loginT");
         form = document.getElementById("create-account-form");
-        if (form.username.value.match(/\W/)) {
-           loginT.innerHTML = "Invalid username<br>";
-           return;
+        if (form.username.value.match(/\W|$^/)) {
+           loginT.innerHTML = "Please enter a valid username<br>";
+           return false;
         }
-        if (!form.email.value.match(/^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/)) {
-           loginT.innerHTML = "Invalid email<br>";
-           return;
+        if (!form.email.value.match(/^(?:[\w.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)?$s/)) {
+           loginT.innerHTML = "Please enter a valid email, or no email at all.<br>";
+           return false;
         }
         if (form.password.value !== form.passwordConfirm.value) {
            loginT.innerHTML = "Passwords don't match<br>";
-           return;
+           return false;
         }
         if (document.getElementById("available").innerHTML !== "\u2714") {
            loginT.innerHTML = "That username is already taken<br>";
-           return;
+           return false;
         }
-        var inputs = form.elements;
-        var data = {};
-        for (var i = 0; i < inputs.length; i++) {
-            if (inputs[i].value === "") {
-                loginT.innerHTML = "Please fill the " +  inputs[i].placeholder + " field.<br>";
-                return;
-            }else {
-                if (inputs[i].name && inputs[i].name !== "passwordConfirm") {
-                    data[inputs[i].name] = inputs[i].value;
-                }
-            }
+        if (form.password.value === "") {
+            loginT.innerHTML = "Please enter a password<br>";
+            return false;
         }
-
-        data = JSON.stringify(data);
-
-        var req = new XMLHttpRequest();
-        req.addEventListener("load", function () {
-            if (JSON.parse(this.response).creationSuccess) {
-                location.href = "/";
-            }else {
-                loginT.innerHTML = "Something went wrong.<br>";
-            }
-        });
-        req.open("POST", "createAccount");
-        req.setRequestHeader("Content-Type", "application/json");
-        req.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
-        req.send(data);
+        if (form.firstName.value === "") {
+            form.firstName.value = form.username.value;
+        }
+        return true;
     };
     var checkUsername=function(){
         var available=document.getElementById("available");
@@ -119,8 +100,9 @@
         <input class="btn" type="submit" value="Login">
     </form>
     <hr>
-    <form action="javascript:createAccount()" id="create-account-form" name="create-account-form">
+    <form method="POST" id="create-account-form" name="create-account-form" onsubmit="return checkNewAccount()">
         <b>Create Account:</b>
+        {% csrf_token %}
         <br>
         <input type="text" name="firstName" placeholder="Name">
         <br>

--- a/django_code/account/views.py
+++ b/django_code/account/views.py
@@ -36,19 +36,17 @@ def login(request):
 
 def createAccount(request):
     if request.method == 'POST':
-        data = json.loads(request.body)
-
-        username = data["username"]
-        email = data["email"]
-        password = data["password"]
-        firstName = data["firstName"]
+        username = request.POST.get('username', '')
+        email = request.POST.get('email', '')
+        password = request.POST.get('password', '')
+        firstName = request.POST.get('firstName', '')
 
         #Checks for valid data. This only confirms what javascript has already checked, so errors
         #don't need to be verobse. It mostly only stops people making their own fake requests.
-        if (username == "" or email == "" or password == "" or firstName == "" or
+        if (username == "" or password == "" or firstName == "" or
             re.match(r"\W", username) or
             User.objects.filter(username=username).exists() or
-            not re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+            not re.match(r"^([\w.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)?$", email)
             ):
             return HttpResponse('{"creationSuccess":false}', content_type="application/json", status=400)
 
@@ -57,11 +55,9 @@ def createAccount(request):
             email,
             password,
         )
-        user.first_name = data["firstName"]
+        user.first_name = firstName
         user.save()
 
         auth.login(request, user)
 
-        response = HttpResponse('{"creationSuccess":true}', content_type="application/json", status=201)
-        response["Location"] = "/user/" + username
-        return response
+        return redirect("/user/" + username)

--- a/django_code/user_profile/templates/user_profile/edit.html
+++ b/django_code/user_profile/templates/user_profile/edit.html
@@ -61,4 +61,3 @@
     </form>
 </body>
 </html>
-


### PR DESCRIPTION
Copied from my commit message on my second commit to this branch:

Switched the create account POST request to follow the example of the
profile edit page. The form is responsible for POSTing the data and
Javascript is used to simply check the validity of the form data. This
lets us avoid XHR’s and JSON, where it doesn’t really make sense.
Additionally:
 - Makes emails optional when signing up
 - Updated the valid-email regular expressions to reflect above
 - Successful account creation now redirects to the new profile instead
of the home page
 - Changed first name field to automatically be filled to username if
not given
 - Changed how empty inputs are checked, username in particular is now
checked by a multipurpose regular expression that catches empty and
invalid usernames

This PR is mostly to help keep track of things. This will be merged after I put this version of the code onto the server and then fix all the many bugs that I'm sure exist.